### PR TITLE
Feat: auto input database name if found in file

### DIFF
--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.ComponentModel;
 using System.Windows.Forms;
 using postgres_database_restore_tool.Helper;
@@ -60,8 +61,16 @@ namespace postgres_database_restore_tool
             var selected = TargetLocation.ShowDialog();
             if (selected == DialogResult.OK)
             {
-                MessageBox.Show(TargetLocation.FileName);
+                MessageBox.Show(TargetLocation.FileName,"File Selected");
                 SelectedFilelbl.Text = TargetLocation.FileName;
+                if(string.IsNullOrWhiteSpace(DatabaseElem.Text))
+                {
+                    var fileName = TargetLocation.FileName.Split(new char[] { '/', '\\' }).LastOrDefault();
+                    if(fileName.Contains("_"))
+                    {
+                        DatabaseElem.Text = fileName.Split('_').FirstOrDefault();
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
### Conditions
1. Database name has not been set.
2. The selected file is in format dbName_xxxx format. Here, the part before the first "_" is set as database name.